### PR TITLE
Update SCA report styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ node ./dist/index.js
 | `-s`  | `--summary`                | Generates an HTML with only the summary, instead of the details report. Defaults to details vulnerability report |
 | `-d`  | `--debug`                  | Runs the CLI in debug mode                                                                                       |
 | `-a`  | `--actionable-remediation` | Display actionable remediation info if available                                                                 |
+| `-m`  | `--modern`                 | Use modern unified template design                                                                 |
 
 When in doubt, use `snyk-to-html --help` or `snyk-to-html -h`.
 

--- a/sca-to-sast-style.css
+++ b/sca-to-sast-style.css
@@ -1,0 +1,580 @@
+:root {
+  --severity-color-critical: #AB1A1A;
+  --severity-color-high: #CE5019;
+  --severity-color-medium: #D68000;
+  --severity-color-low: #88879E;
+}
+
+
+  body {
+    -moz-font-feature-settings: "pnum";
+    -webkit-font-feature-settings: "pnum";
+    font-variant-numeric: proportional-nums;
+    display: flex;
+    flex-direction: column;
+    font-feature-settings: "pnum";
+    font-size: 100%;
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-text-size-adjust: 100%;
+    margin: 0;
+    padding: 0;
+    color: #393842;
+    font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 500;
+  }
+
+  a,
+  a:link,
+  a:visited {
+    border-bottom: 1px solid #4b45a9;
+    text-decoration: none;
+    color: #4b45a9;
+  }
+
+  a:hover,
+  a:focus,
+  a:active {
+    border-bottom: 1px solid #4b45a9;
+  }
+
+  hr {
+    border: none;
+    margin: 1em 0;
+    border-top: 1px solid #c5c5c5;
+  }
+
+  ul {
+    padding: 0 1em;
+    margin: 1em 0;
+  }
+
+  code {
+    background-color: #EEE;
+    color: #333;
+    padding: 0.25em 0.5em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    font-size: 14px;
+  }
+
+  pre code {
+    padding: 10px;
+    font-family: monospace;
+    background-color: #393842;
+    border-radius: 4px;
+    color: #fff;
+    display: block;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    max-width: 100%;
+    min-width: 100px;
+  }
+
+  a code {
+    border-radius: .125rem .125rem 0 0;
+    padding-bottom: 0;
+    color: #4b45a9;
+  }
+
+  a[href^="http://"]:after,
+  a[href^="https://"]:after:not(.brand) {
+    background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20id%3D%22Page-1%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20id%3D%22link-external%22%3E%3Cg%20id%3D%22arrow%22%3E%3Cpath%20id%3D%22Line%22%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20id%3D%22Triangle%22%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20id%3D%22square%22%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-size: .75rem;
+    content: "";
+    display: inline-block;
+    height: .75rem;
+    margin-left: .25rem;
+    width: .75rem;
+  }
+
+
+/* Layout */
+
+  [class*=layout-container] {
+    margin: 0 auto;
+    max-width: 71.25em;
+    padding: 20px;
+    position: relative;
+  }
+  .layout-container--short {
+    padding-top: 0;
+    padding-bottom: 0;
+    max-width: 48.75em;
+  }
+
+  .layout-container--short:after {
+    display: block;
+    content: "";
+    clear: both;
+  }
+
+/* Header */
+
+  .header {
+    padding-bottom: 1px;
+  }
+
+  .paths {
+    margin-left: 8px;
+    font-size:14px;
+  }
+
+  .project__header {
+    background-color: #4b45a9;
+    background-image: linear-gradient(to right, #7530a6 0%, #461d9f 50%);
+    color: #fff;
+    }
+
+  .project__header__title {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-all;
+    margin-top: 0;
+    margin-bottom: 12px;
+  }
+
+  .meta-count {
+    display: inline-block;
+    margin: 0 12px 6px 0;
+    padding-right: 12px;
+    font-size:14px;
+  }
+
+/* Card */
+
+  .card {
+    background-color: #fff;
+    border: 1px solid #c5c5c5;
+    border-radius: .25rem;
+    margin: 0 0 2em 0;
+    position: relative;
+    min-height: 40px;
+    padding: 0;
+  }
+
+  .card .label {
+    background-color: #767676;
+    border: 2px solid #767676;
+    color: white;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    display: inline-block;
+    margin: 0;
+    border-radius: 0.25rem;
+  }
+
+  .card .label__text {
+    vertical-align: text-top;
+      font-weight: bold;
+  }
+
+  .card .label--critical {
+    background-color: var(--severity-color-critical);
+    border-color: var(--severity-color-critical);
+  }
+
+  .card .label--high {
+    background-color: var(--severity-color-high);
+    border-color: var(--severity-color-high);
+  }
+
+  .card .label--medium {
+    background-color: var(--severity-color-medium);
+    border-color: var(--severity-color-medium);
+  }
+
+  .card .label--low {
+    background-color: var(--severity-color-low);
+    border-color: var(--severity-color-low);
+  }
+
+  .severity--low {
+    border-color: var(--severity-color-low);
+  }
+
+  .severity--medium {
+    border-color: var(--severity-color-medium);
+  }
+
+  .severity--high {
+    border-color: var(--severity-color-high);
+  }
+
+  .severity--critical {
+    border-color: var(--severity-color-critical);
+  }
+
+  .card--vuln {
+    padding-top: 4em;
+  }
+
+  .card--vuln .label {
+    left: 0;
+    position: absolute;
+    top: 1.1em;
+    padding-left: 1.9em;
+    padding-right: 1.9em;
+    border-radius: 0 0.25rem 0.25rem 0;
+  }
+
+  .card__section {
+    background-color: #faf9fa
+  }
+
+  .card__section h2 {
+    font-size: 22px;
+    margin-bottom: 0.5em;
+  }
+
+  .card__section p {
+    margin: 0 0 12px 0;
+  }
+
+  .card__meta {
+    padding: 0;
+    margin-top: 10px;
+    font-size: 1.1em;
+  }
+
+  .card__meta__item {
+    display: inline-block;
+  }
+
+  .card .card__meta__paths {
+    font-size: 0.9em;
+  }
+
+  .card__title {
+    font-size: 28px;
+    margin-top: 0;
+  }
+
+  .card__cta p {
+    margin: 0;
+    text-align: right;
+  }
+
+/* Styles by Andy */
+
+.brand, .brand:link, .brand:visited { display:inline-block; border:none; }
+.brand::after { background:none; }
+
+.test-meta { float:right; max-width:500px; opacity:.75; font-size:12px; text-align: right; }
+.test-meta .filepath { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.test-meta .timestamp { margin:0 0 6px }
+
+.report-summary { display:flex; justify-content: space-between; margin-bottom: 24px; }
+.header-wrap, .source-panel { align-self: center; }
+.severity-icon { display:inline-block; width:32px; height: 32px;  }
+.severity-icon.severity-icon--critical { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iI0FCMUExQSIvPgo8cGF0aCBkPSJNMTkuNTYyNSAxOC4zMzk4SDIzLjA2NjRDMjIuOTk2MSAxOS40ODgzIDIyLjY3OTcgMjAuNTA3OCAyMi4xMTcyIDIxLjM5ODRDMjEuNTYyNSAyMi4yODkxIDIwLjc4NTIgMjIuOTg0NCAxOS43ODUyIDIzLjQ4NDRDMTguNzkzIDIzLjk4NDQgMTcuNTk3NyAyNC4yMzQ0IDE2LjE5OTIgMjQuMjM0NEMxNS4xMDU1IDI0LjIzNDQgMTQuMTI1IDI0LjA0NjkgMTMuMjU3OCAyMy42NzE5QzEyLjM5MDYgMjMuMjg5MSAxMS42NDg0IDIyLjc0MjIgMTEuMDMxMiAyMi4wMzEyQzEwLjQyMTkgMjEuMzIwMyA5Ljk1NzAzIDIwLjQ2MDkgOS42MzY3MiAxOS40NTMxQzkuMzE2NDEgMTguNDQ1MyA5LjE1NjI1IDE3LjMxNjQgOS4xNTYyNSAxNi4wNjY0VjE0Ljg4MjhDOS4xNTYyNSAxMy42MzI4IDkuMzIwMzEgMTIuNTAzOSA5LjY0ODQ0IDExLjQ5NjFDOS45ODQzOCAxMC40ODA1IDEwLjQ2MDkgOS42MTcxOSAxMS4wNzgxIDguOTA2MjVDMTEuNzAzMSA4LjE5NTMxIDEyLjQ0OTIgNy42NDg0NCAxMy4zMTY0IDcuMjY1NjJDMTQuMTgzNiA2Ljg4MjgxIDE1LjE1MjMgNi42OTE0MSAxNi4yMjI3IDYuNjkxNDFDMTcuNjQ0NSA2LjY5MTQxIDE4Ljg0MzggNi45NDkyMiAxOS44MjAzIDcuNDY0ODRDMjAuODA0NyA3Ljk4MDQ3IDIxLjU2NjQgOC42OTE0MSAyMi4xMDU1IDkuNTk3NjZDMjIuNjUyMyAxMC41MDM5IDIyLjk4MDUgMTEuNTM1MiAyMy4wODk4IDEyLjY5MTRIMTkuNTc0MkMxOS41MzUyIDEyLjAwMzkgMTkuMzk4NCAxMS40MjE5IDE5LjE2NDEgMTAuOTQ1M0MxOC45Mjk3IDEwLjQ2MDkgMTguNTc0MiAxMC4wOTc3IDE4LjA5NzcgOS44NTU0N0MxNy42Mjg5IDkuNjA1NDcgMTcuMDAzOSA5LjQ4MDQ3IDE2LjIyMjcgOS40ODA0N0MxNS42MzY3IDkuNDgwNDcgMTUuMTI1IDkuNTg5ODQgMTQuNjg3NSA5LjgwODU5QzE0LjI1IDEwLjAyNzMgMTMuODgyOCAxMC4zNTk0IDEzLjU4NTkgMTAuODA0N0MxMy4yODkxIDExLjI1IDEzLjA2NjQgMTEuODEyNSAxMi45MTggMTIuNDkyMkMxMi43NzczIDEzLjE2NDEgMTIuNzA3IDEzLjk1MzEgMTIuNzA3IDE0Ljg1OTRWMTYuMDY2NEMxMi43MDcgMTYuOTQ5MiAxMi43NzM0IDE3LjcyNjYgMTIuOTA2MiAxOC4zOTg0QzEzLjAzOTEgMTkuMDYyNSAxMy4yNDIyIDE5LjYyNSAxMy41MTU2IDIwLjA4NTlDMTMuNzk2OSAyMC41MzkxIDE0LjE1NjIgMjAuODgyOCAxNC41OTM4IDIxLjExNzJDMTUuMDM5MSAyMS4zNDM4IDE1LjU3NDIgMjEuNDU3IDE2LjE5OTIgMjEuNDU3QzE2LjkzMzYgMjEuNDU3IDE3LjUzOTEgMjEuMzM5OCAxOC4wMTU2IDIxLjEwNTVDMTguNDkyMiAyMC44NzExIDE4Ljg1NTUgMjAuNTIzNCAxOS4xMDU1IDIwLjA2MjVDMTkuMzYzMyAxOS42MDE2IDE5LjUxNTYgMTkuMDI3MyAxOS41NjI1IDE4LjMzOThaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) }
+.severity-icon.severity-icon--high { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iI0NFNTAxOSIvPgo8cGF0aCBkPSJNMjAuNDI5NyAxMy44ODY3VjE2LjYyODlIMTEuNTIzNFYxMy44ODY3SDIwLjQyOTdaTTEyLjU2NjQgNi45Mzc1VjI0SDkuMDUwNzhWNi45Mzc1SDEyLjU2NjRaTTIyLjkzNzUgNi45Mzc1VjI0SDE5LjQzMzZWNi45Mzc1SDIyLjkzNzVaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) }
+.severity-icon.severity-icon--medium { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iI0Q2ODAwMCIvPgo8cGF0aCBkPSJNOC42MTcxOSA2LjkzNzVIMTEuNTkzOEwxNS45NzY2IDE5LjQ2NDhMMjAuMzU5NCA2LjkzNzVIMjMuMzM1OUwxNy4xNzE5IDI0SDE0Ljc4MTJMOC42MTcxOSA2LjkzNzVaTTcuMDExNzIgNi45Mzc1SDkuOTc2NTZMMTAuNTE1NiAxOS4xNDg0VjI0SDcuMDExNzJWNi45Mzc1Wk0yMS45NzY2IDYuOTM3NUgyNC45NTMxVjI0SDIxLjQzNzVWMTkuMTQ4NEwyMS45NzY2IDYuOTM3NVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=) }
+.severity-icon.severity-icon--low { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iIzg4ODc5RSIvPgo8cGF0aCBkPSJNMjIgMjEuMjU3OFYyNEgxMy40MTAyVjIxLjI1NzhIMjJaTTE0LjU0NjkgNi45Mzc1VjI0SDExLjAzMTJWNi45Mzc1SDE0LjU0NjlaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) }
+.meta-count .severity-icon { float:left; width:24px; height:24px; margin-right:6px; background-size: 24px 24px; }
+
+.source-panel { text-align: right; }
+.source-panel__heading { display:block; margin-top:6px; text-transform:uppercase; color:#727184; font-size:12px; }
+.scan-coverage { max-width: 400px; padding:0; margin:12px 0 0; font-size:14px; }
+.scan-coverage .type { display:inline-block; list-style-type: none; padding:3px; margin:0 0 0 10px; }
+
+.card.severity--low { --severity-color: var(--severity-color-low); }
+.card.severity--medium { --severity-color: var(--severity-color-medium); }
+.card.severity--high { --severity-color: var(--severity-color-high); }
+.card.severity--critical { --severity-color: var(--severity-color-critical); }
+.card {
+  padding:0;
+  border-width:4px 1px 1px;
+  border-color:#d3d3d9;
+  border-top-color: var(--severity-color);
+  border-radius: 4px 4px 0 0;
+}
+
+.card__tab__radio { display: none; pointer-events: none; }
+.dataflow, .fix-analysis { display: none; }
+
+.card input[id^="tab-dataflow"]:checked ~ .card__header .card__action[for^="tab-dataflow"] {
+  background-color: var(--severity-color);
+  color: #fff;
+  border-radius: 20px;
+}
+
+.card input[id^="tab-fix"]:checked ~ .card__header .card__action[for^="tab-fix"] {
+  background-color: #4b45a1;
+  color: #fff;
+  border-radius: 20px;
+}
+
+.card input[id^="tab-dataflow"]:checked ~ .card__section .dataflow,
+.card input[id^="tab-fix"]:checked ~ .card__section .fix-analysis {
+  display: block;
+}
+
+.card__header { padding:24px }
+.card__header__main { display:flex; }
+.card__header__main .severity-icon { margin-right:12px; }
+.card__meta { display:flex; align-items:flex-start; margin:0; list-style:none; }
+.card__meta__item { display:inline-block; padding-right:8px; border-right:1px solid #eee; margin-right: 8px; font-size:12px; color:#727184 }
+.card__meta__item:last-child { border:none; }
+.card .card__title { display:inline-block; margin:0; font-size:22px; font-weight:600; vertical-align: top;}
+
+.card__actions { display:flex; padding:2px; border:1px solid #d3d3d9; border-radius:20px; background-color:#fff;  margin-left: auto; }
+.card__action { align-self: center; padding:5px 15px; font-size:14px; cursor: pointer; transition: all .2s; }
+.card__action:hover { color: #4b45a1; }
+
+.card__section {padding:24px; border-top: 1px solid #d3d3d9}
+
+.card__snippet { background-color: transparent; font-family: monospace; white-space: pre; margin: 1em 0px;  }
+
+.card__summary { position: relative; padding: 16px 24px; border: 1px solid #d3d3d9; border-left-width:4px; border-radius:2px; background-color:#fff; color:#393842; word-break: break-word; }
+.card__summary.severity--critical { border-left-color:var(--severity-color-critical) ; }
+.card__summary.severity--high { border-left-color:var(--severity-color-high) ; }
+.card__summary.severity--medium { border-left-color:var(--severity-color-medium) ; }
+.card__summary.severity--low { border-left-color:var(--severity-color-low); }
+.card__summary .file-location { margin-top:12px; font-size:13px; color:#727184 }
+
+.dataflow { margin:12px 0 }
+.dataflow__item, .code-source { display: flex; padding:4px 8px; border:1px solid transparent; border-width: 1px 0; font-family: monospace; color:#393842; font-size:14px }
+.dataflow__item:hover { cursor:pointer; border-color: #eee; background-color:#fff; }
+.dataflow__item:hover .marker { background-color: #ffc905; }
+.dataflow__step, .dataflow__lineno, .code-lineno { align-self: flex-start; flex:0 0 50px; width: 50px; text-align: right; color:#727184; font-size:12px; }
+.dataflow__step  { flex:0 0 30px; width: 30px; }
+.dataflow__lineno { flex:0 0 60px;  padding:0 20px 0 0; }
+.dataflow__code { display:flex; align-self: flex-start; align-content: flex-start; flex-grow: 1; margin-right:40px; line-height:1; overflow:auto; }
+.dataflow__code h1, .dataflow__code h2, .dataflow__code h3, .dataflow__code h4, .dataflow__code h5, .dataflow__code h6, .dataflow__code strong, .dataflow__code b, .dataflow__code em, .dataflow__code i, .dataflow__code p  { padding:0; margin:0; font-family: monospace; color:#393842; font-size:14px; font-weight:400; font-style: normal;  } /* overriding html default styling within the code */
+.dataflow__code br { display:none  } /* overriding html default styling within the code */
+.dataflow__code .dataflow__codeprefix, .dataflow__code .dataflow__codesuffix { display:inline-block; margin:0; white-space:nowrap } 
+.dataflow__badge { align-self:flex-start; padding:2px 3px; border:1px solid #d3d3d9; border-radius:2px; margin-top:2px; background-color:#f4f4f6; font-size:11px; line-height:1; font-family: sans-serif; text-transform: uppercase; color:#646374 } 
+.dataflow__filename { padding:6px 12px; border:1px solid #eee; border-radius: 4px; margin:20px 0 10px; font-size:13px; color:#393842; background-color: #fff; }
+
+.marker { padding:2px 6px; border-radius:4px; background-color: rgba(0,0,0,.1); word-break: break-all; white-space: nowrap; }
+.marker.block { white-space: pre; line-height: 1.5; }
+
+.card .card__section h2, .card .card__section h3 { font-size:18px; } 
+.card__panel__heading { padding:5px 0; font-size:22px; font-weight: 600; }
+.heading-char { display: inline-block; width:22px; height:22px; border:1px solid #d3d3d9; border-radius:15px; margin-right:5px; color:#727184; font-size:14px; background-color:#fff; text-align: center; }
+
+.card__panel__markdown { font-size:14px; color:#393842; }
+.card__panel__markdown table { border-collapse: collapse; border:1px solid #d3d3d9; border-radius:3px; }
+.card__panel__markdown tbody { display: table-row-group; vertical-align: top; }
+.card__panel__markdown table td, .card__panel__markdown table th { min-width: 100px; padding:2px 5px; text-align: left; border-top:1px solid #d3d3d9; }
+.card__panel__markdown table td { background-color:#fff; font-size:14px; line-height: 1.4; }
+
+.is-hidden { display:none; }
+
+@media print { 
+  /* All your print styles go here */
+   .card .fix-analysis { display:block; }
+   .card__section { background-color: none; }
+   .project__header, .card__actions, .severity-icon { display: none; }
+   .marker { border:1px solid #555; margin:-1px 0; background: transparent }
+}
+
+  .remediation-card {
+    background-color: #edecf6;
+    border-radius: 2px;
+    padding: 1px;
+    box-shadow: inset 0 0 0 1px #938fc7, 0 0 0 2px transparent;
+    border-radius: 2px;
+  }
+  .remediation-card__header {
+    align-items: center;
+    background-color: #fff;
+    border-radius: 4px 4px 0 0;
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+  }
+  .remediation-card__body {
+    background-color: #edecf6;
+    border-top-color: #938fc7;
+    padding: 0;
+    border-top: 1px solid #d3d3d9;
+    position: relative;
+  }
+  .remediation-card__layout-container {
+    max-width: 1440px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 20px;
+  }
+  .remediation-card__pane.shown {
+    background-color: #fff;
+    border-top: 1px solid #d3d3d9;
+    padding: 32px 0;
+    display: block;
+    visibility: visible;
+    height: auto;
+  }
+  .remediation-card__pane {
+    display: none;
+    visibility: hidden;
+    height: 0;
+  }
+  .remediation-card__nav {
+    position: relative;
+    top: 1px;
+  }
+  .remediation-card__nav-list {
+    display: flex;
+    margin: 0 0;
+    padding: 0 0;
+  }
+  .remediation-card__nav-item {
+    white-space: nowrap;
+    list-style-type: none;
+    color: #4b45a1;
+    margin: 0;
+  }
+  .remediation-card__nav-item.active {
+    background-color: #fff;
+    white-space: nowrap;
+    list-style-type: none;
+    color: #4b45a1;
+    margin: 0;
+  }
+  .remediation-card__nav-link {
+    color: #727184;
+    border: 1px solid transparent;
+    border-top-width: 3px;
+    border-bottom-color: #d3d3d9;
+    display: inline-block;
+    height: 44px;
+    padding: 12px 16px 12px;
+    cursor: pointer;
+    font-size: 1rem;
+    outline: none;
+  }
+  .remediation-card__nav-item.active > .remediation-card__nav-link {
+    color: #393842;
+    border: 1px solid #d3d3d9;
+    border-bottom: none;
+    border-top: 3px solid var(--severity-color-medium);
+    border-radius: .25rem .25rem 0 0;
+    display: inline-block;
+    height: 44px;
+    padding: 12px 16px 12px;
+    cursor: pointer;
+    font-size: 1rem;
+    outline: none;
+  }
+  .remediation-card__block {
+    background-color: #fff;
+    box-shadow: inset 0 0 0 1px hsl(244, 8%, 84%);
+    border-radius: 2px;
+    padding: 1px;
+    margin-top: 12px;
+  }
+  .remediation-card__expandable-container {
+    cursor: pointer;
+    align-items: stretch;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    position: relative;
+  }
+  .remediation-card__expandable-wrapper >  .remediation-card__expand {
+    visibility: hidden;
+    height: 0;
+    display: none;
+  }
+
+  .remediation-card__expandable-wrapper.shown > .remediation-card__expand {
+    visibility: visible;
+    height: auto;
+    display: block;
+  }
+
+  .remediation-card__expandable-title {
+    align-items: center;
+    display: flex;
+    font-size: 1rem;
+    padding: 12px;
+    position: relative;
+    width: 100%;
+  }
+  .remediation-card__chevron {
+    display: inline-block;
+    margin-right: 8px;
+    transition: transform .2s ease-in-out;
+    position: relative;
+  }
+  .remediation-card__expandable-wrapper svg {
+    transform: rotate(-90deg);
+  }
+  .remediation-card__expandable-wrapper.shown svg {
+    transform: initial;
+  }
+  .remediation-card__chevron .block-expandable__chevron {
+    width: 20px;
+    height: 20px;
+  }
+  .remediation-card__chevron .scoped {
+    display: inline-block;
+    fill: currentColor;
+    overflow: hidden;
+    vertical-align: middle;
+  }
+  .remediation-card__severity {
+    margin-right: 8px;
+    font-size: .75rem;
+    line-height: 1.35;
+  }
+  .remediation-card__severity-text {
+    padding: 0;
+    text-align: center;
+    width: 26px;
+    color: white;
+    margin-right: 8px;
+    font-size: .75rem;
+  }
+  .remediation-card__severity-label {
+    position: relative;
+    top: 1px;
+  }
+
+  .remediation-card__severity--critical {
+    background-color: #ab1a1a;
+    border-color: #ab1a1a;
+  }
+  .remediation-card__severity--high {
+    background-color: var(--severity-color-high);
+    border-color: var(--severity-color-high);
+  }
+  .remediation-card__severity--medium {
+    background-color: var(--severity-color-medium);
+    border-color: var(--severity-color-medium);
+  }
+  .remediation-card__severity--low {
+    background-color: var(--severity-color-low);
+    border-color: var(--severity-color-low);
+  }
+  .remediation-card__h2 {
+    color: #393842;
+    display: block;
+    padding: 16px 24px 12px;
+    width: 100%;
+  }
+  .remediation-card__item {
+    padding-left: 0;
+    padding-right: 0;
+    list-style: none;
+  }
+  .remediation-card__vuln {
+    align-items: center;
+    border-top: 1px solid #b3b2bd;
+    display: flex;
+    padding: 12px;
+  }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ program
     '-a, --actionable-remediation',
     'Display actionable remediation info if available',
   )
+  .option(
+    '-m, --modern',
+    'Use modern unified template design',
+  )
   .parse(process.argv);
 
 let template;
@@ -41,11 +45,15 @@ if (program.template) {
     if (program.actionableRemediation) {
       template = path.join(__dirname, '../template/remediation-report.hbs');
     } else {
-      template = path.join(__dirname, '../template/test-report.hbs');
+      template = program.modern
+        ? path.join(__dirname, '../template/modern/test-report.hbs')
+        : path.join(__dirname, '../template/test-report.hbs');
     }
   }
 } else {
-  if (program.actionableRemediation) {
+  if (program.modern) {
+    template = path.join(__dirname, '../template/modern/test-report.hbs');
+  } else if (program.actionableRemediation) {
     template = path.join(__dirname, '../template/remediation-report.hbs');
   } else {
     template = path.join(__dirname, '../template/test-report.hbs');

--- a/src/lib/snyk-to-html.ts
+++ b/src/lib/snyk-to-html.ts
@@ -194,6 +194,10 @@ async function registerPeerPartial(
   Handlebars.registerPartial(name, template);
 }
 
+function isModernTemplate(templatePath: string): boolean {
+  return templatePath.includes(`${path.sep}modern${path.sep}`);
+}
+
 async function generateTemplate(
   data: any,
   template: string,
@@ -228,14 +232,23 @@ async function generateTemplate(
     data.packageManager = data.paths[0].packageManager;
   }
 
-  await registerPeerPartial(template, 'inline-css');
-  await registerPeerPartial(template, 'header');
-  await registerPeerPartial(template, 'metatable-css');
-  await registerPeerPartial(template, 'metatable');
-  await registerPeerPartial(template, 'inline-js');
-  await registerPeerPartial(template, 'vuln-card');
-  await registerPeerPartial(template, 'remediation-css');
-  await registerPeerPartial(template, 'actionable-remediations');
+  if (isModernTemplate(template)) {
+    await registerPeerPartial(template, 'modern-inline-css');
+    await registerPeerPartial(template, 'modern-header');
+    await registerPeerPartial(template, 'modern-metatable-css');
+    await registerPeerPartial(template, 'modern-metatable');
+    await registerPeerPartial(template, 'modern-inline-js');
+    await registerPeerPartial(template, 'modern-vuln-card');
+  } else {
+    await registerPeerPartial(template, 'inline-css');
+    await registerPeerPartial(template, 'header');
+    await registerPeerPartial(template, 'metatable-css');
+    await registerPeerPartial(template, 'metatable');
+    await registerPeerPartial(template, 'inline-js');
+    await registerPeerPartial(template, 'vuln-card');
+    await registerPeerPartial(template, 'remediation-css');
+    await registerPeerPartial(template, 'actionable-remediations');
+  }
 
   const htmlTemplate = await compileTemplate(template);
   return htmlTemplate(data);
@@ -245,12 +258,21 @@ async function generateIacTemplate(
   data: any,
   template: string,
 ): Promise<string> {
-  await registerPeerPartial(template, 'inline-css');
-  await registerPeerPartial(template, 'header');
-  await registerPeerPartial(template, 'metatable-css');
-  await registerPeerPartial(template, 'metatable');
-  await registerPeerPartial(template, 'inline-js');
-  await registerPeerPartial(template, 'vuln-card');
+  if (isModernTemplate(template)) {
+    await registerPeerPartial(template, 'modern-inline-css');
+    await registerPeerPartial(template, 'modern-header');
+    await registerPeerPartial(template, 'modern-metatable-css');
+    await registerPeerPartial(template, 'modern-metatable');
+    await registerPeerPartial(template, 'modern-inline-js');
+    await registerPeerPartial(template, 'modern-vuln-card');
+  } else {
+    await registerPeerPartial(template, 'inline-css');
+    await registerPeerPartial(template, 'header');
+    await registerPeerPartial(template, 'metatable-css');
+    await registerPeerPartial(template, 'metatable');
+    await registerPeerPartial(template, 'inline-js');
+    await registerPeerPartial(template, 'vuln-card');
+  }
 
   const htmlTemplate = await compileTemplate(template);
 
@@ -261,12 +283,21 @@ async function generateCodeTemplate(
   data: any,
   template: string,
 ): Promise<string> {
-  await registerPeerPartial(template, 'inline-css');
-  await registerPeerPartial(template, 'inline-js');
-  await registerPeerPartial(template, 'header');
-  await registerPeerPartial(template, 'metatable-css');
-  await registerPeerPartial(template, 'metatable');
-  await registerPeerPartial(template, 'code-snip');
+  if (isModernTemplate(template)) {
+    await registerPeerPartial(template, 'modern-inline-css');
+    await registerPeerPartial(template, 'modern-inline-js');
+    await registerPeerPartial(template, 'modern-header');
+    await registerPeerPartial(template, 'modern-metatable-css');
+    await registerPeerPartial(template, 'modern-metatable');
+    await registerPeerPartial(template, 'code-snip');
+  } else {
+    await registerPeerPartial(template, 'inline-css');
+    await registerPeerPartial(template, 'inline-js');
+    await registerPeerPartial(template, 'header');
+    await registerPeerPartial(template, 'metatable-css');
+    await registerPeerPartial(template, 'metatable');
+    await registerPeerPartial(template, 'code-snip');
+  }
 
   const htmlTemplate = await compileTemplate(template);
 

--- a/template/modern/test-report.hbs
+++ b/template/modern/test-report.hbs
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Snyk test report</title>
+  <meta name="description" content="{{uniqueCount}} known vulnerabilities found in {{summary}}.">
+  <base target="_blank">
+  <link rel="icon" type="image/png" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png"
+    sizes="194x194">
+  <link rel="shortcut icon" href="https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico">
+  {{> modern-inline-css }}
+  {{> modern-metatable-css }}
+</head>
+
+<body class="section-projects">
+  <main class="layout-stacked">
+    {{> modern-header }}
+    {{#if hasMetatableData}}
+      {{> modern-metatable }}
+    {{/if}}
+
+    <div class="layout-container" style="padding-top: 35px;">
+    {{#if vulnerabilities}}
+      <div class="cards--vuln filter--patch filter--ignore">
+        {{#each vulnerabilities}}
+        {{> modern-vuln-card showSummaryOnly=../showSummaryOnly}}
+        {{/each}}
+      </div><!-- cards -->
+    {{else}}
+      No known vulnerabilities detected.
+    {{/if}}
+    </div>
+  </main><!-- .layout-stacked__content -->
+  {{> modern-inline-js }}
+</body>
+
+</html>

--- a/template/modern/test-report.modern-header.hbs
+++ b/template/modern/test-report.modern-header.hbs
@@ -1,0 +1,51 @@
+    <div class="layout-stacked__header header">
+      <header class="project__header">
+        <div class="layout-container">
+          <a class="brand" href="https://snyk.io" title="Snyk">
+            <svg width="68px" height="35px" viewBox="0 0 68 35" version="1.1" xmlns="http://www.w3.org/2000/svg" role="img">
+              <title>Snyk - Open Source Security</title>
+              <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g fill="#fff">
+                  <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"></path>
+                </g>
+              </g>
+            </svg>
+          </a>
+          <div class="header-wrap">
+            {{#unless showSummaryOnly}}
+              <h1 class="project__header__title">Snyk test report</h1>
+            {{else}}
+              <h1 class="project__header__title">Snyk test summary</h1>
+            {{/unless}}
+
+            <p class="timestamp">{{moment d "MMMM Do YYYY, h:mm:ss a (zZ)"}}</p>
+          </div>
+          {{#if paths}}
+          <div class="source-panel">
+            <span>Scanned the following paths:</span>
+            <ul>
+            {{#each paths}}
+              <li class="paths">{{path}}{{#if displayTargetFile}}/{{displayTargetFile}}{{/if}} ({{packageManager}})</li>
+            {{/each}}
+            </ul>
+          </div>
+          {{/if}}
+          {{#if path}}
+          <div class="source-panel">
+            <span>Scanned the following path:</span>
+            <ul>
+              <li class="paths">{{path}}{{#if displayTargetFile}}/{{displayTargetFile}}{{/if}} ({{packageManager}})</li>
+            </ul>
+          </div>
+          {{/if}}
+
+          <div class="meta-counts">
+            <div class="meta-count"><span>{{uniqueCount}}</span> <span>known vulnerabilities</span></div>
+            {{#if_not_eq packageManager "Unmanaged (C/C++)"}}
+            <div class="meta-count"><span>{{summary}}</span></div>
+            {{/if_not_eq}}
+            <div class="meta-count"><span>{{dependencyCount}}</span> <span>dependencies</span></div>
+          </div><!-- .meta-counts -->
+        </div><!-- .layout-container--short -->
+      </header><!-- .project__header -->
+    </div><!-- .layout-stacked__header -->

--- a/template/modern/test-report.modern-inline-css.hbs
+++ b/template/modern/test-report.modern-inline-css.hbs
@@ -1,0 +1,583 @@
+<style type="text/css">
+:root {
+  --severity-color-critical: #AB1A1A;
+  --severity-color-high: #CE5019;
+  --severity-color-medium: #D68000;
+  --severity-color-low: #88879E;
+}
+
+
+  body {
+    -moz-font-feature-settings: "pnum";
+    -webkit-font-feature-settings: "pnum";
+    font-variant-numeric: proportional-nums;
+    display: flex;
+    flex-direction: column;
+    font-feature-settings: "pnum";
+    font-size: 100%;
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-text-size-adjust: 100%;
+    margin: 0;
+    padding: 0;
+    color: #393842;
+    font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 500;
+  }
+
+  a,
+  a:link,
+  a:visited {
+    border-bottom: 1px solid #4b45a9;
+    text-decoration: none;
+    color: #4b45a9;
+  }
+
+  a:hover,
+  a:focus,
+  a:active {
+    border-bottom: 1px solid #4b45a9;
+  }
+
+  hr {
+    border: none;
+    margin: 1em 0;
+    border-top: 1px solid #c5c5c5;
+  }
+
+  ul {
+    padding: 0 1em;
+    margin: 1em 0;
+  }
+
+  code {
+    background-color: #EEE;
+    color: #333;
+    padding: 0.25em 0.5em;
+    border-radius: 0.25em;
+  }
+
+  pre {
+    font-size: 14px;
+  }
+
+  pre code {
+    padding: 10px;
+    font-family: monospace;
+    background-color: #393842;
+    border-radius: 4px;
+    color: #fff;
+    display: block;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    max-width: 100%;
+    min-width: 100px;
+  }
+
+  a code {
+    border-radius: .125rem .125rem 0 0;
+    padding-bottom: 0;
+    color: #4b45a9;
+  }
+
+  a[href^="http://"]:after,
+  a[href^="https://"]:after:not(.brand) {
+    background-image: linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20id%3D%22Page-1%22%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20id%3D%22link-external%22%3E%3Cg%20id%3D%22arrow%22%3E%3Cpath%20id%3D%22Line%22%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20id%3D%22Triangle%22%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20id%3D%22square%22%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-size: .75rem;
+    content: "";
+    display: inline-block;
+    height: .75rem;
+    margin-left: .25rem;
+    width: .75rem;
+  }
+
+
+/* Layout */
+
+  [class*=layout-container] {
+    margin: 0 auto;
+    max-width: 71.25em;
+    padding: 20px;
+    position: relative;
+  }
+  .layout-container--short {
+    padding-top: 0;
+    padding-bottom: 0;
+    max-width: 48.75em;
+  }
+
+  .layout-container--short:after {
+    display: block;
+    content: "";
+    clear: both;
+  }
+
+/* Header */
+
+  .header {
+    padding-bottom: 1px;
+  }
+
+  .paths {
+    margin-left: 8px;
+    font-size:14px;
+  }
+
+  .project__header {
+    background-color: #4b45a9;
+    background-image: linear-gradient(to right, #7530a6 0%, #461d9f 50%);
+    color: #fff;
+    }
+
+  .project__header__title {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-all;
+    margin-top: 0;
+    margin-bottom: 12px;
+  }
+
+  .meta-count {
+    display: inline-block;
+    margin: 0 12px 6px 0;
+    padding-right: 12px;
+    font-size:14px;
+  }
+
+/* Card */
+
+  .card {
+    background-color: #fff;
+    border: 1px solid #c5c5c5;
+    border-radius: .25rem;
+    margin: 0 0 2em 0;
+    position: relative;
+    min-height: 40px;
+    padding: 0;
+  }
+
+  .card .label {
+    background-color: #767676;
+    border: 2px solid #767676;
+    color: white;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    display: inline-block;
+    margin: 0;
+    border-radius: 0.25rem;
+  }
+
+  .card .label__text {
+    vertical-align: text-top;
+      font-weight: bold;
+  }
+
+  .card .label--critical {
+    background-color: var(--severity-color-critical);
+    border-color: var(--severity-color-critical);
+  }
+
+  .card .label--high {
+    background-color: var(--severity-color-high);
+    border-color: var(--severity-color-high);
+  }
+
+  .card .label--medium {
+    background-color: var(--severity-color-medium);
+    border-color: var(--severity-color-medium);
+  }
+
+  .card .label--low {
+    background-color: var(--severity-color-low);
+    border-color: var(--severity-color-low);
+  }
+
+  .severity--low {
+    border-color: var(--severity-color-low);
+  }
+
+  .severity--medium {
+    border-color: var(--severity-color-medium);
+  }
+
+  .severity--high {
+    border-color: var(--severity-color-high);
+  }
+
+  .severity--critical {
+    border-color: var(--severity-color-critical);
+  }
+
+  .card--vuln {
+    padding-top: 4em;
+  }
+
+  .card--vuln .label {
+    left: 0;
+    position: absolute;
+    top: 1.1em;
+    padding-left: 1.9em;
+    padding-right: 1.9em;
+    border-radius: 0 0.25rem 0.25rem 0;
+  }
+
+  .card__section {
+    background-color: #faf9fa
+  }
+
+  .card__section h2 {
+    font-size: 22px;
+    margin-bottom: 0.5em;
+  }
+
+  .card__section p {
+    margin: 0 0 12px 0;
+  }
+
+  .card__meta {
+    padding: 0;
+    margin-top: 10px;
+    font-size: 1.1em;
+  }
+
+  .card__meta__item {
+    display: inline-block;
+  }
+
+  .card .card__meta__paths {
+    font-size: 0.9em;
+  }
+
+  .card__title {
+    font-size: 28px;
+    margin-top: 0;
+  }
+
+  .card__cta p {
+    margin: 0;
+    text-align: right;
+  }
+
+/* Styles by Andy */
+
+.brand, .brand:link, .brand:visited { display:inline-block; border:none; }
+.brand::after { background:none; }
+
+.test-meta { float:right; max-width:500px; opacity:.75; font-size:12px; text-align: right; }
+.test-meta .filepath { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.test-meta .timestamp { margin:0 0 6px }
+
+.report-summary { display:flex; justify-content: space-between; margin-bottom: 24px; }
+.header-wrap, .source-panel { align-self: center; }
+.severity-icon { display:inline-block; width:32px; height: 32px;  }
+.severity-icon.severity-icon--critical { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iI0FCMUExQSIvPgo8cGF0aCBkPSJNMTkuNTYyNSAxOC4zMzk4SDIzLjA2NjRDMjIuOTk2MSAxOS40ODgzIDIyLjY3OTcgMjAuNTA3OCAyMi4xMTcyIDIxLjM5ODRDMjEuNTYyNSAyMi4yODkxIDIwLjc4NTIgMjIuOTg0NCAxOS43ODUyIDIzLjQ4NDRDMTguNzkzIDIzLjk4NDQgMTcuNTk3NyAyNC4yMzQ0IDE2LjE5OTIgMjQuMjM0NEMxNS4xMDU1IDI0LjIzNDQgMTQuMTI1IDI0LjA0NjkgMTMuMjU3OCAyMy42NzE5QzEyLjM5MDYgMjMuMjg5MSAxMS42NDg0IDIyLjc0MjIgMTEuMDMxMiAyMi4wMzEyQzEwLjQyMTkgMjEuMzIwMyA5Ljk1NzAzIDIwLjQ2MDkgOS42MzY3MiAxOS40NTMxQzkuMzE2NDEgMTguNDQ1MyA5LjE1NjI1IDE3LjMxNjQgOS4xNTYyNSAxNi4wNjY0VjE0Ljg4MjhDOS4xNTYyNSAxMy42MzI4IDkuMzIwMzEgMTIuNTAzOSA5LjY0ODQ0IDExLjQ5NjFDOS45ODQzOCAxMC40ODA1IDEwLjQ2MDkgOS42MTcxOSAxMS4wNzgxIDguOTA2MjVDMTEuNzAzMSA4LjE5NTMxIDEyLjQ0OTIgNy42NDg0NCAxMy4zMTY0IDcuMjY1NjJDMTQuMTgzNiA2Ljg4MjgxIDE1LjE1MjMgNi42OTE0MSAxNi4yMjI3IDYuNjkxNDFDMTcuNjQ0NSA2LjY5MTQxIDE4Ljg0MzggNi45NDkyMiAxOS44MjAzIDcuNDY0ODRDMjAuODA0NyA3Ljk4MDQ3IDIxLjU2NjQgOC42OTE0MSAyMi4xMDU1IDkuNTk3NjZDMjIuNjUyMyAxMC41MDM5IDIyLjk4MDUgMTEuNTM1MiAyMy4wODk4IDEyLjY5MTRIMTkuNTc0MkMxOS41MzUyIDEyLjAwMzkgMTkuMzk4NCAxMS40MjE5IDE5LjE2NDEgMTAuOTQ1M0MxOC45Mjk3IDEwLjQ2MDkgMTguNTc0MiAxMC4wOTc3IDE4LjA5NzcgOS44NTU0N0MxNy42Mjg5IDkuNjA1NDcgMTcuMDAzOSA5LjQ4MDQ3IDE2LjIyMjcgOS40ODA0N0MxNS42MzY3IDkuNDgwNDcgMTUuMTI1IDkuNTg5ODQgMTQuNjg3NSA5LjgwODU5QzE0LjI1IDEwLjAyNzMgMTMuODgyOCAxMC4zNTk0IDEzLjU4NTkgMTAuODA0N0MxMy4yODkxIDExLjI1IDEzLjA2NjQgMTEuODEyNSAxMi45MTggMTIuNDkyMkMxMi43NzczIDEzLjE2NDEgMTIuNzA3IDEzLjk1MzEgMTIuNzA3IDE0Ljg1OTRWMTYuMDY2NEMxMi43MDcgMTYuOTQ5MiAxMi43NzM0IDE3LjcyNjYgMTIuOTA2MiAxOC4zOTg0QzEzLjAzOTEgMTkuMDYyNSAxMy4yNDIyIDE5LjYyNSAxMy41MTU2IDIwLjA4NTlDMTMuNzk2OSAyMC41MzkxIDE0LjE1NjIgMjAuODgyOCAxNC41OTM4IDIxLjExNzJDMTUuMDM5MSAyMS4zNDM4IDE1LjU3NDIgMjEuNDU3IDE2LjE5OTIgMjEuNDU3QzE2LjkzMzYgMjEuNDU3IDE3LjUzOTEgMjEuMzM5OCAxOC4wMTU2IDIxLjEwNTVDMTguNDkyMiAyMC44NzExIDE4Ljg1NTUgMjAuNTIzNCAxOS4xMDU1IDIwLjA2MjVDMTkuMzYzMyAxOS42MDE2IDE5LjUxNTYgMTkuMDI3MyAxOS41NjI1IDE4LjMzOThaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) }
+.severity-icon.severity-icon--high { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iI0NFNTAxOSIvPgo8cGF0aCBkPSJNMjAuNDI5NyAxMy44ODY3VjE2LjYyODlIMTEuNTIzNFYxMy44ODY3SDIwLjQyOTdaTTEyLjU2NjQgNi45Mzc1VjI0SDkuMDUwNzhWNi45Mzc1SDEyLjU2NjRaTTIyLjkzNzUgNi45Mzc1VjI0SDE5LjQzMzZWNi45Mzc1SDIyLjkzNzVaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) }
+.severity-icon.severity-icon--medium { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iI0Q2ODAwMCIvPgo8cGF0aCBkPSJNOC42MTcxOSA2LjkzNzVIMTEuNTkzOEwxNS45NzY2IDE5LjQ2NDhMMjAuMzU5NCA2LjkzNzVIMjMuMzM1OUwxNy4xNzE5IDI0SDE0Ljc4MTJMOC42MTcxOSA2LjkzNzVaTTcuMDExNzIgNi45Mzc1SDkuOTc2NTZMMTAuNTE1NiAxOS4xNDg0VjI0SDcuMDExNzJWNi45Mzc1Wk0yMS45NzY2IDYuOTM3NUgyNC45NTMxVjI0SDIxLjQzNzVWMTkuMTQ4NEwyMS45NzY2IDYuOTM3NVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=) }
+.severity-icon.severity-icon--low { background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIgZmlsbD0iIzg4ODc5RSIvPgo8cGF0aCBkPSJNMjIgMjEuMjU3OFYyNEgxMy40MTAyVjIxLjI1NzhIMjJaTTE0LjU0NjkgNi45Mzc1VjI0SDExLjAzMTJWNi45Mzc1SDE0LjU0NjlaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) }
+.meta-count .severity-icon { float:left; width:24px; height:24px; margin-right:6px; background-size: 24px 24px; }
+
+.source-panel { text-align: right; }
+.source-panel__heading { display:block; margin-top:6px; text-transform:uppercase; color:#727184; font-size:12px; }
+.scan-coverage { max-width: 400px; padding:0; margin:12px 0 0; font-size:14px; }
+.scan-coverage .type { display:inline-block; list-style-type: none; padding:3px; margin:0 0 0 10px; }
+
+.card.severity--low { --severity-color: var(--severity-color-low); }
+.card.severity--medium { --severity-color: var(--severity-color-medium); }
+.card.severity--high { --severity-color: var(--severity-color-high); }
+.card.severity--critical { --severity-color: var(--severity-color-critical); }
+.card {
+  padding:0;
+  border-width:4px 1px 1px;
+  border-color:#d3d3d9;
+  border-top-color: var(--severity-color);
+  border-radius: 4px 4px 0 0;
+}
+
+.card__tab__radio { display: none; pointer-events: none; }
+.dataflow, .fix-analysis { display: none; }
+
+.card input[id^="tab-dataflow"]:checked ~ .card__header .card__action[for^="tab-dataflow"] {
+  background-color: var(--severity-color);
+  color: #fff;
+  border-radius: 20px;
+}
+
+.card input[id^="tab-fix"]:checked ~ .card__header .card__action[for^="tab-fix"] {
+  background-color: #4b45a1;
+  color: #fff;
+  border-radius: 20px;
+}
+
+.card input[id^="tab-dataflow"]:checked ~ .card__section .dataflow,
+.card input[id^="tab-fix"]:checked ~ .card__section .fix-analysis {
+  display: block;
+}
+
+.card__header { padding:24px }
+.card__header__main { display:flex; }
+.card__header__main .severity-icon { margin-right:12px; }
+.card__meta { display:flex; align-items:flex-start; margin:0; list-style:none; }
+.card__meta__item { display:inline-block; padding-right:8px; border-right:1px solid #eee; margin-right: 8px; font-size:12px; color:#727184 }
+.card__meta__item:last-child { border:none; }
+.card .card__title { display:inline-block; margin:0; font-size:22px; font-weight:600; vertical-align: top;}
+
+.card__actions { display:flex; padding:2px; border:1px solid #d3d3d9; border-radius:20px; background-color:#fff;  margin-left: auto; }
+.card__action { align-self: center; padding:5px 15px; font-size:14px; cursor: pointer; transition: all .2s; }
+.card__action:hover { color: #4b45a1; }
+
+.card__section {padding:24px; border-top: 1px solid #d3d3d9}
+
+.card__snippet { background-color: transparent; font-family: monospace; white-space: pre; margin: 1em 0px;  }
+
+.card__summary { position: relative; padding: 16px 24px; border: 1px solid #d3d3d9; border-left-width:4px; border-radius:2px; background-color:#fff; color:#393842; word-break: break-word; }
+.card__summary.severity--critical { border-left-color:var(--severity-color-critical) ; }
+.card__summary.severity--high { border-left-color:var(--severity-color-high) ; }
+.card__summary.severity--medium { border-left-color:var(--severity-color-medium) ; }
+.card__summary.severity--low { border-left-color:var(--severity-color-low); }
+.card__summary .file-location { margin-top:12px; font-size:13px; color:#727184 }
+
+.dataflow { margin:12px 0 }
+.dataflow__item, .code-source { display: flex; padding:4px 8px; border:1px solid transparent; border-width: 1px 0; font-family: monospace; color:#393842; font-size:14px }
+.dataflow__item:hover { cursor:pointer; border-color: #eee; background-color:#fff; }
+.dataflow__item:hover .marker { background-color: #ffc905; }
+.dataflow__step, .dataflow__lineno, .code-lineno { align-self: flex-start; flex:0 0 50px; width: 50px; text-align: right; color:#727184; font-size:12px; }
+.dataflow__step  { flex:0 0 30px; width: 30px; }
+.dataflow__lineno { flex:0 0 60px;  padding:0 20px 0 0; }
+.dataflow__code { display:flex; align-self: flex-start; align-content: flex-start; flex-grow: 1; margin-right:40px; line-height:1; overflow:auto; }
+.dataflow__code h1, .dataflow__code h2, .dataflow__code h3, .dataflow__code h4, .dataflow__code h5, .dataflow__code h6, .dataflow__code strong, .dataflow__code b, .dataflow__code em, .dataflow__code i, .dataflow__code p  { padding:0; margin:0; font-family: monospace; color:#393842; font-size:14px; font-weight:400; font-style: normal;  } /* overriding html default styling within the code */
+.dataflow__code br { display:none  } /* overriding html default styling within the code */
+.dataflow__code .dataflow__codeprefix, .dataflow__code .dataflow__codesuffix { display:inline-block; margin:0; white-space:nowrap } 
+.dataflow__badge { align-self:flex-start; padding:2px 3px; border:1px solid #d3d3d9; border-radius:2px; margin-top:2px; background-color:#f4f4f6; font-size:11px; line-height:1; font-family: sans-serif; text-transform: uppercase; color:#646374 } 
+.dataflow__filename { padding:6px 12px; border:1px solid #eee; border-radius: 4px; margin:20px 0 10px; font-size:13px; color:#393842; background-color: #fff; }
+
+.marker { padding:2px 6px; border-radius:4px; background-color: rgba(0,0,0,.1); word-break: break-all; white-space: nowrap; }
+.marker.block { white-space: pre; line-height: 1.5; }
+
+.card .card__section h2, .card .card__section h3 { font-size:18px; } 
+.card__panel__heading { padding:5px 0; font-size:22px; font-weight: 600; }
+.heading-char { display: inline-block; width:22px; height:22px; border:1px solid #d3d3d9; border-radius:15px; margin-right:5px; color:#727184; font-size:14px; background-color:#fff; text-align: center; }
+
+.card__panel__markdown { font-size:14px; color:#393842; }
+.card__panel__markdown table { border-collapse: collapse; border:1px solid #d3d3d9; border-radius:3px; }
+.card__panel__markdown tbody { display: table-row-group; vertical-align: top; }
+.card__panel__markdown table td, .card__panel__markdown table th { min-width: 100px; padding:2px 5px; text-align: left; border-top:1px solid #d3d3d9; }
+.card__panel__markdown table td { background-color:#fff; font-size:14px; line-height: 1.4; }
+
+.is-hidden { display:none; }
+
+@media print { 
+  /* All your print styles go here */
+   .card .fix-analysis { display:block; }
+   .card__section { background-color: none; }
+   .project__header, .card__actions, .severity-icon { display: none; }
+   .marker { border:1px solid #555; margin:-1px 0; background: transparent }
+}
+
+  .remediation-card {
+    background-color: #edecf6;
+    border-radius: 2px;
+    padding: 1px;
+    box-shadow: inset 0 0 0 1px #938fc7, 0 0 0 2px transparent;
+    border-radius: 2px;
+  }
+  .remediation-card__header {
+    align-items: center;
+    background-color: #fff;
+    border-radius: 4px 4px 0 0;
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+  }
+  .remediation-card__body {
+    background-color: #edecf6;
+    border-top-color: #938fc7;
+    padding: 0;
+    border-top: 1px solid #d3d3d9;
+    position: relative;
+  }
+  .remediation-card__layout-container {
+    max-width: 1440px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 20px;
+  }
+  .remediation-card__pane.shown {
+    background-color: #fff;
+    border-top: 1px solid #d3d3d9;
+    padding: 32px 0;
+    display: block;
+    visibility: visible;
+    height: auto;
+  }
+  .remediation-card__pane {
+    display: none;
+    visibility: hidden;
+    height: 0;
+  }
+  .remediation-card__nav {
+    position: relative;
+    top: 1px;
+  }
+  .remediation-card__nav-list {
+    display: flex;
+    margin: 0 0;
+    padding: 0 0;
+  }
+  .remediation-card__nav-item {
+    white-space: nowrap;
+    list-style-type: none;
+    color: #4b45a1;
+    margin: 0;
+  }
+  .remediation-card__nav-item.active {
+    background-color: #fff;
+    white-space: nowrap;
+    list-style-type: none;
+    color: #4b45a1;
+    margin: 0;
+  }
+  .remediation-card__nav-link {
+    color: #727184;
+    border: 1px solid transparent;
+    border-top-width: 3px;
+    border-bottom-color: #d3d3d9;
+    display: inline-block;
+    height: 44px;
+    padding: 12px 16px 12px;
+    cursor: pointer;
+    font-size: 1rem;
+    outline: none;
+  }
+  .remediation-card__nav-item.active > .remediation-card__nav-link {
+    color: #393842;
+    border: 1px solid #d3d3d9;
+    border-bottom: none;
+    border-top: 3px solid var(--severity-color-medium);
+    border-radius: .25rem .25rem 0 0;
+    display: inline-block;
+    height: 44px;
+    padding: 12px 16px 12px;
+    cursor: pointer;
+    font-size: 1rem;
+    outline: none;
+  }
+  .remediation-card__block {
+    background-color: #fff;
+    box-shadow: inset 0 0 0 1px hsl(244, 8%, 84%);
+    border-radius: 2px;
+    padding: 1px;
+    margin-top: 12px;
+  }
+  .remediation-card__expandable-container {
+    cursor: pointer;
+    align-items: stretch;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    position: relative;
+  }
+  .remediation-card__expandable-wrapper >  .remediation-card__expand {
+    visibility: hidden;
+    height: 0;
+    display: none;
+  }
+
+  .remediation-card__expandable-wrapper.shown > .remediation-card__expand {
+    visibility: visible;
+    height: auto;
+    display: block;
+  }
+
+  .remediation-card__expandable-title {
+    align-items: center;
+    display: flex;
+    font-size: 1rem;
+    padding: 12px;
+    position: relative;
+    width: 100%;
+  }
+  .remediation-card__chevron {
+    display: inline-block;
+    margin-right: 8px;
+    transition: transform .2s ease-in-out;
+    position: relative;
+  }
+  .remediation-card__expandable-wrapper svg {
+    transform: rotate(-90deg);
+  }
+  .remediation-card__expandable-wrapper.shown svg {
+    transform: initial;
+  }
+  .remediation-card__chevron .block-expandable__chevron {
+    width: 20px;
+    height: 20px;
+  }
+  .remediation-card__chevron .scoped {
+    display: inline-block;
+    fill: currentColor;
+    overflow: hidden;
+    vertical-align: middle;
+  }
+  .remediation-card__severity {
+    margin-right: 8px;
+    font-size: .75rem;
+    line-height: 1.35;
+  }
+  .remediation-card__severity-text {
+    padding: 0;
+    text-align: center;
+    width: 26px;
+    color: white;
+    margin-right: 8px;
+    font-size: .75rem;
+  }
+  .remediation-card__severity-label {
+    position: relative;
+    top: 1px;
+  }
+
+  .remediation-card__severity--critical {
+    background-color: #ab1a1a;
+    border-color: #ab1a1a;
+  }
+  .remediation-card__severity--high {
+    background-color: var(--severity-color-high);
+    border-color: var(--severity-color-high);
+  }
+  .remediation-card__severity--medium {
+    background-color: var(--severity-color-medium);
+    border-color: var(--severity-color-medium);
+  }
+  .remediation-card__severity--low {
+    background-color: var(--severity-color-low);
+    border-color: var(--severity-color-low);
+  }
+  .remediation-card__h2 {
+    color: #393842;
+    display: block;
+    padding: 16px 24px 12px;
+    width: 100%;
+  }
+  .remediation-card__item {
+    padding-left: 0;
+    padding-right: 0;
+    list-style: none;
+  }
+  .remediation-card__vuln {
+    align-items: center;
+    border-top: 1px solid #b3b2bd;
+    display: flex;
+    padding: 12px;
+  }
+
+</style>

--- a/template/modern/test-report.modern-inline-js.hbs
+++ b/template/modern/test-report.modern-inline-js.hbs
@@ -1,0 +1,54 @@
+<script>
+  // collapse vulns in remediations
+  const remediations = document.querySelectorAll(".js-remediation");
+  remediations.forEach((remediation) => {
+    remediation.parentElement.classList.toggle("shown");
+    remediation.addEventListener("click", remediationClick);
+  })
+
+  // hide all panes
+  const allPanes = document.querySelectorAll(`[data-pane]`);
+  allPanes.forEach((pane) => {
+    pane.classList.remove('shown');
+  });
+  // set first nav item as active & un-hide it's pane
+  const remediationNav = document.querySelectorAll(".js-nav");
+  remediationNav.forEach((nav) => {
+    nav.addEventListener("click", navClick);
+  })
+  if (remediationNav && remediationNav.length > 0) {
+    remediationNav[0].classList.add('active');
+    const targetPaneData = remediationNav[0].dataset && remediationNav[0].dataset.toggle;
+    if (targetPaneData) {
+      showPane(targetPaneData);
+    }
+  }
+
+  function remediationClick() {
+    this.parentElement.classList.toggle("shown");
+  }
+
+  function navClick() {
+    const remediationNav = document.querySelectorAll(".js-nav");
+    remediationNav.forEach((nav) => {
+      nav.classList.remove('active');
+    });
+    this.classList.toggle('active');
+    const targetPaneData = this.dataset && this.dataset.toggle;
+    if (targetPaneData) {
+      showPane(targetPaneData);
+    }
+  }
+
+  function showPane(targetPaneData) {
+    const targetPanes = document.querySelectorAll(`[data-pane='${targetPaneData}']`);
+    if (targetPanes) {
+      const allPanes = document.querySelectorAll(`[data-pane]`);
+      allPanes.forEach((pane) => {
+        pane.classList.remove('shown');
+      });
+      targetPanes[0].classList.add('shown');
+    }
+  }
+
+</script>

--- a/template/modern/test-report.modern-metatable-css.hbs
+++ b/template/modern/test-report.modern-metatable-css.hbs
@@ -1,0 +1,127 @@
+<style type="text/css">
+  .metatable {
+    text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-direction: normal;
+    color: inherit;
+    font-feature-settings: "pnum";
+    box-sizing: border-box;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    font-size: 100%;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    text-align: left;
+    text-decoration: none;
+    vertical-align: baseline;
+    z-index: auto;
+    margin-top: 12px;
+    border-collapse: collapse;
+    border-spacing: 0;
+    font-variant-numeric: tabular-nums;
+    max-width: 51.75em;
+  }
+
+  tbody {
+    text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-direction: normal;
+    color: inherit;
+    font-feature-settings: "pnum";
+    border-collapse: collapse;
+    border-spacing: 0;
+    box-sizing: border-box;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    font-size: 100%;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    text-align: left;
+    text-decoration: none;
+    vertical-align: baseline;
+    z-index: auto;
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .meta-row {
+    text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-direction: normal;
+    color: inherit;
+    font-feature-settings: "pnum";
+    border-collapse: collapse;
+    border-spacing: 0;
+    box-sizing: border-box;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    font-size: 100%;
+    outline: none;
+    text-align: left;
+    text-decoration: none;
+    vertical-align: baseline;
+    z-index: auto;
+    display: flex;
+    align-items: start;
+    border-top: 1px solid #d3d3d9;
+    padding: 8px 0 0 0;
+    border-bottom: none;
+    margin: 8px;
+    width: 47.75%;
+  }
+
+  .meta-row-label {
+    text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-direction: normal;
+    font-feature-settings: "pnum";
+    border-collapse: collapse;
+    border-spacing: 0;
+    color: #4c4a73;
+    box-sizing: border-box;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    margin: 0;
+    outline: none;
+    text-decoration: none;
+    z-index: auto;
+    align-self: start;
+    flex: 1;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    padding: 0;
+    text-align: left;
+    vertical-align: top;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  .meta-row-value {
+    text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-direction: normal;
+    color: inherit;
+    font-feature-settings: "pnum";
+    border-collapse: collapse;
+    border-spacing: 0;
+    word-break: break-word;
+    box-sizing: border-box;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    font-size: 100%;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    text-align: right;
+    text-decoration: none;
+    vertical-align: baseline;
+    z-index: auto;
+  }
+</style>

--- a/template/modern/test-report.modern-metatable.hbs
+++ b/template/modern/test-report.modern-metatable.hbs
@@ -1,0 +1,10 @@
+<section class="layout-container">
+    <table class="metatable">
+        <tbody>
+        {{#if projectName}}<tr class="meta-row"><th class="meta-row-label">Project</th> <td class="meta-row-value">{{projectName}}</td></tr>{{/if}}
+        {{#if path}}<tr class="meta-row"><th class="meta-row-label">Path</th> <td class="meta-row-value">{{path}}</td></tr>{{/if}}
+        {{#if packageManager}}<tr class="meta-row"><th class="meta-row-label">Package Manager</th> <td class="meta-row-value">{{packageManager}}</td></tr>{{/if}}
+        {{#if displayTargetFile}}<tr class="meta-row"><th class="meta-row-label">Manifest</th> <td class="meta-row-value">{{displayTargetFile}}</td></tr>{{/if}}
+        </tbody>
+    </table>
+</section>

--- a/template/modern/test-report.modern-vuln-card.hbs
+++ b/template/modern/test-report.modern-vuln-card.hbs
@@ -1,0 +1,162 @@
+<div class="card card--vuln  disclosure--not-new severity--{{metadata.severity}}" data-snyk-test="{{metadata.severity}}">
+    <h2 class="card__title">{{metadata.title}}</h2>
+    <div class="card__section">
+
+        <div class="label label--{{metadata.severity}}">
+            <span class="label__text">{{metadata.severity}} severity</span>
+        </div>
+
+        <hr/>
+
+        <ul class="card__meta">
+            {{#if list.[0].displayTargetFile }}
+            <li class="card__meta__item">
+                Manifest file: {{list.[0].path}} <span class="list-paths__item__arrow">›</span> {{list.[0].displayTargetFile}}
+            </li>
+            {{/if}}
+            <li class="card__meta__item">
+                Package Manager: {{metadata.packageManager}}
+            </li>
+            <li class="card__meta__item">
+                {{#if_eq list.0.type "license"}}
+                    Module:
+                {{else}}
+                    Vulnerable module:
+                {{/if_eq}}
+
+                {{#if_eq metadata.type "npm"}}
+                    <a href="/test/{{@root.project.type}}/{{metadata.name}}">{{metadata.name}}</a>
+                {{else}}
+                    {{metadata.name}}
+                {{/if_eq}}
+            </li>
+
+            {{#if_not_eq list.[0].packageManager "Unmanaged (C/C++)"}}
+            <li class="card__meta__item">Introduced through:
+                {{#if_eq metadata.packageManager "npm"}}
+                    {{#if_eq (count list.[0].from) 1}}
+                        <a href="/test/{{@root.project.type}}/{{list.[0].from.[0]}}">
+                            {{list.[0].from}}
+                        </a>
+                    {{/if_eq}}
+                {{else}}
+                    {{#if_eq (count list.[0].from) 1}}
+                        {{list.[0].from}}
+                    {{/if_eq}}
+                {{/if_eq}}
+
+                {{#if_eq @root.project.type "npm"}}
+                    {{#if_eq (count list.[0].from) 2}}
+                        <a href="/test/{{@root.project.type}}/{{list.[0].from.[0]}}">
+                            {{list.[0].from.[0]}}
+                        </a>
+                        and
+                        <a href="/test/{{@root.project.type}}/{{list.[0].from.[1]}}">
+                            {{list.[0].from.[1]}}
+                        </a>
+                    {{/if_eq}}
+                {{else}}
+                    {{#if_eq (count list.[0].from) 2}}
+                        {{list.[0].from.[0]}} and {{list.[0].from.[1]}}
+                    {{/if_eq}}
+
+                    {{#if_eq @root.project.type "npm"}}
+                        {{#ifCond (count list.[0].from) '>=' 3}}
+                            <a href="/test/{{@root.project.type}}/{{list.[0].from.[0]}}">{{list.[0].from.[0]}}</a>,
+                            <a href="/test/{{@root.project.type}}/{{list.[0].from.[1]}}">{{list.[0].from.[1]}}</a> and others
+                        {{/ifCond}}
+                    {{else}}
+                        {{#ifCond (count list.[0].from) '>=' 3}}
+                            {{list.[0].from.[0]}}, {{list.[0].from.[1]}} and others
+                        {{/ifCond}}
+                    {{/if_eq}}
+                {{/if_eq}}
+            </li>
+            {{/if_not_eq}}
+        </ul>
+
+        {{#if_not_eq list.[0].packageManager "Unmanaged (C/C++)"}}
+        <hr/>
+
+        {{#unless showSummaryOnly}}
+
+            {{#if_eq @root.project.type "npm"}}
+                <h3 class="card__section__title">Detailed paths and remediation</h3>
+            {{else}}
+                <h3 class="card__section__title">Detailed paths</h3>
+            {{/if_eq}}
+
+            <ul class="card__meta__paths">
+                {{#each list}}
+                    {{#isDoubleArray from}}
+                        {{#each .}}
+                        <li class="list-paths__item">
+                            <span class="list-paths__item__introduced"><em>Introduced through</em>:
+                                {{#each .}}
+                                    {{.}}
+                                    {{#unless @last}} <span class="list-paths__item__arrow">›</span> {{/unless}}
+                                {{/each}}
+                            </span>
+                        {{/each}}
+                    {{else}}
+                        <li>
+                        <span class="list-paths__item__introduced"><em>Introduced through</em>:
+                            {{#each .}}
+                                {{.}}
+                                {{#unless @last}} <span class="list-paths__item__arrow">›</span> {{/unless}}
+                            {{/each}}
+                        </span>
+                    {{/isDoubleArray}}
+
+                    {{#if_eq @root.project.type "npm"}}
+                        <span class="list-paths__item__remediation">
+                        <strong>Remediation:</strong>
+                        {{#if_any isUpgradable isPatchable}}
+                            {{#upgradeAvailable upgradePath}}{{!-- Direct dependency with upgrade. --}}
+                                {{#if_eq upgradePath.[1] from.[1]}}{{!-- Dependencies are out of date. --}}
+                                    Your dependencies are out of date, otherwise you would be using a newer {{name}} than {{name}}@{{version}}.
+                                    Try deleting node_modules.
+                                    If the problem persists, one of your dependencies may be bundling outdated modules.
+                                {{else}}{{!-- Dependencies are not out of date. --}}
+                                    Upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}}.
+                                {{/if_eq}}
+                                {{else}}{{!-- This is not a direct dependency, but there is an upgrade --}}
+                                    {{#if @root.isTest}}{{!-- This is a test page --}}
+                                    No direct dependency upgrade can address this issue.
+                                    If possible, manually upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}},
+                                    or run <code><a href="/docs/using-snyk/#monitor">snyk monitor</a></code> to get notified when an easier upgrade or a patch becomes available.
+                                    {{else}}{{!-- This is a monitor page --}}
+                                    No direct dependency upgrade can address this issue.
+                                    If possible, manually upgrade to {{#firstNonFalse upgradePath}}{{.}}{{/firstNonFalse}}.
+                                    We'll notify you when an easier upgrade or a patch is available.
+                                    {{/if}}
+                            {{/upgradeAvailable}}
+                        {{else}}{{!-- There are no upgrades or patches --}}
+                            No remediation path available.
+                        {{/if_any}}
+                        </span><!-- .list-paths__item__remediation -->
+                    {{/if_eq}}
+                    </li>
+                {{/each}}
+            </ul><!-- .list-paths -->
+        {{/unless}}
+        {{/if_not_eq}}
+
+    </div><!-- .card__section -->
+
+    {{#unless showSummaryOnly}}
+      <hr/>
+      <!-- Overview -->
+      {{{markdown metadata.description}}}
+      <hr/>
+    {{else}}
+      {{#if metadata}}
+        {{{getRemediation metadata.description metadata.fixedIn}}}
+      {{/if}}
+    {{/unless}}
+
+    <div class="cta card__cta">
+        <p><a href="https://snyk.io/vuln/{{metadata.id}}">More about this vulnerability</a></p>
+    </div>
+
+</div><!-- .card -->

--- a/test/snyk-to-html.spec.ts
+++ b/test/snyk-to-html.spec.ts
@@ -431,4 +431,17 @@ describe('test running SnykToHtml.run', () => {
       },
     );
   });
+
+  it('creates a modern style report', () => {
+    SnykToHtml.run(
+      path.join(__dirname, 'fixtures', 'test-report.json'),
+      WITHOUT_REMEDIATION,
+      path.join(__dirname, '..', 'template', 'modern', 'test-report.hbs'),
+      WITHOUT_SUMMARY,
+      (report) => {
+        expect(report).toContain('--severity-color-high');
+        expect(report).toContain('layout-stacked__header');
+      },
+    );
+  });
 });

--- a/updated-sast-report.html
+++ b/updated-sast-report.html
@@ -1,0 +1,130 @@
+<!--
+Migration Notes
+- uses unified css via sca-to-sast-style.css
+- layout mirrors updated-sca-report.html
+- sample content derived from Snyk Code fixture
+- checked cross-browser and print styles
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Snyk Code Test Report</title>
+  <base target="_blank">
+  <link rel="stylesheet" href="sca-to-sast-style.css">
+</head>
+<body class="section-projects">
+  <main class="layout-stacked">
+    <div class="layout-stacked__header header">
+      <header class="project__header">
+        <div class="layout-container">
+          <a class="brand" href="https://snyk.io" title="Snyk">
+            <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img">
+              <title>Snyk - Open Source Security</title>
+              <g fill="#fff"><path d="M5.732 27.278C3.445 27.278 1.589 26.885 0 26.124l.483-3.652C2.163 23.296 4.056 23.689 5.643 23.689c1.158 0 1.92-.394 1.92-1.09 0-2.005-7.23-1.523-7.23-6.76 0-3.348 3.074-5.11 6.926-5.11 1.92 0 3.902.52 5.185.975l-.52 3.59c-1.347-.52-3.177-1.003-4.702-1.003-.94 0-1.704.33-1.704.94 0 1.977 7.385 1.584 7.385 6.694 0 3.4-3.026 5.352-7.17 5.352zM25.726 26.936V17.894c0-2.067-.915-3.044-2.657-3.044-.85 0-1.74.24-2.35.61v11.476h-5.367V11.262l5.25-.432-.128 2.562h.178c1.132-1.522 3.05-2.676 5.34-2.676 2.744 0 5.12 1.7 5.12 5.72v10.5h-5.388zM61.175 26.936l-4.296-7.457h-.433v7.456H51.082V8.37l5.365-8.37v17.323c1.068-1.306 4.665-6.264 4.665-6.264h6.62l-6.278 6.63 6.495 9.261h-6.774zM44.13 11.11l-2.2 7.152c-.43 1.344-.85 3.817-.85 3.817s-.33-2.563-.788-3.907l-2.352-7.154H31.928l6.534 15.827c-.89 2.105-2.263 3.88-4.093 3.88-.33 0-.66-.013-.98-.05l-2.134 3.296c.673.38 1.957.774 3.482.774 3.966 0 6.622-3.208 8.478-7.95l6.228-15.777H44.13z"/></g>
+            </svg>
+          </a>
+          <div class="header-wrap">
+            <h1 class="project__header__title">Snyk Code Report</h1>
+            <p class="timestamp">TIMESTAMP</p>
+          </div>
+          <div class="source-panel">
+            <span>Scanned repository:</span>
+            <ul>
+              <li class="paths">/path/to/repository (java)</li>
+            </ul>
+          </div>
+          <div class="meta-counts">
+            <div class="meta-count"><span class="severity-icon severity-icon--high"></span> <span><strong>1</strong> high issue</span></div>
+            <div class="meta-count"><span class="severity-icon severity-icon--medium"></span> <span><strong>2</strong> medium issues</span></div>
+            <div class="meta-count"><span class="severity-icon severity-icon--low"></span> <span><strong>0</strong> low issues</span></div>
+          </div>
+        </div>
+      </header>
+    </div>
+    <section class="layout-container">
+      <table class="metatable">
+        <tbody>
+          <tr class="meta-row"><th class="meta-row-label">Project</th> <td class="meta-row-value">demo-code</td></tr>
+          <tr class="meta-row"><th class="meta-row-label">Path</th> <td class="meta-row-value">/path/to/repository</td></tr>
+          <tr class="meta-row"><th class="meta-row-label">Language</th> <td class="meta-row-value">Java</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <div class="layout-container" style="padding-top:35px;">
+      <div class="cards--vuln filter--patch filter--ignore">
+        <div class="card card--vuln severity--high" data-snyk-test="high">
+          <input type="radio" name="tab-view-0" id="tab-dataflow-0" value="dataflow" class="card__tab__radio" checked>
+          <input type="radio" name="tab-view-0" id="tab-fix-0" value="fix" class="card__tab__radio">
+          <header class="card__header">
+            <div class="card__header__main">
+              <div class="severity-icon severity-icon--high"></div>
+              <h2 class="card__title">Use of Password Hash With Insufficient Computational Effort</h2>
+              <div class="card__actions">
+                <label for="tab-dataflow-0" class="card__action">Data Flow</label>
+                <label for="tab-fix-0" class="card__action">Fix Analysis</label>
+              </div>
+            </div>
+            <ul class="card__meta">
+              <li class="card__meta__item">SNYK-CODE</li>
+              <li class="card__meta__item">CWE-916</li>
+              <li class="card__meta__item">InsecureHash</li>
+            </ul>
+          </header>
+          <div class="card__section">
+            <div class="label label--high"><span class="label__text">high severity</span></div>
+            <div class="card__summary severity--high">
+              <p>The SHA1 hash is insecure. Consider using a stronger algorithm.</p>
+              <div class="file-location">Found in: <strong>SHA1.java (line : 51)</strong></div>
+            </div>
+            <div class="card__panel dataflow" data-pane="dataflow">
+              <h2 class="card__panel__heading"><span class="heading-char">⇣</span> Data Flow</h2>
+              <div class="dataflow__item">
+                <span class="dataflow__lineno">51:1</span>
+                <div class="dataflow__code"><span class="marker">DigestUtils.sha1Hex(input)</span></div>
+                <span class="dataflow__badge">Source</span>
+              </div>
+            </div>
+            <div class="card__panel fix-analysis" data-pane="fix">
+              <h2 class="card__panel__heading"><span class="heading-char">✓</span> Fix Analysis</h2>
+              <div class="card__panel__markdown"><p>Replace SHA1 with SHA256.</p></div>
+            </div>
+          </div>
+          <div class="cta card__cta"><p><a href="https://snyk.io/vuln/SNYK-JAVA-1234">More about this issue</a></p></div>
+        </div>
+      </div>
+    </div>
+  </main>
+<script>
+  const remediations = document.querySelectorAll('.js-remediation');
+  remediations.forEach(r => { r.parentElement.classList.toggle('shown'); r.addEventListener('click', remediationClick); });
+  const allPanes = document.querySelectorAll('[data-pane]');
+  allPanes.forEach(p => { p.classList.remove('shown'); });
+  const remediationNav = document.querySelectorAll('.js-nav');
+  remediationNav.forEach(nav => { nav.addEventListener('click', navClick); });
+  if (remediationNav && remediationNav.length > 0) {
+    remediationNav[0].classList.add('active');
+    const targetPaneData = remediationNav[0].dataset && remediationNav[0].dataset.toggle;
+    if (targetPaneData) { showPane(targetPaneData); }
+  }
+  function remediationClick(){ this.parentElement.classList.toggle('shown'); }
+  function navClick(){
+    const remediationNav=document.querySelectorAll('.js-nav');
+    remediationNav.forEach(nav=>{ nav.classList.remove('active'); });
+    this.classList.toggle('active');
+    const targetPaneData=this.dataset&&this.dataset.toggle;
+    if(targetPaneData){ showPane(targetPaneData); }
+  }
+  function showPane(targetPaneData){
+    const targetPanes=document.querySelectorAll(`[data-pane='${targetPaneData}']`);
+    if(targetPanes){
+      const allPanes=document.querySelectorAll('[data-pane]');
+      allPanes.forEach(p=>{ p.classList.remove('shown'); });
+      targetPanes[0].classList.add('shown');
+    }
+  }
+</script>
+</body>
+</html>

--- a/updated-sca-report.html
+++ b/updated-sca-report.html
@@ -1,0 +1,130 @@
+<!--
+Migration Notes
+- added css via sca-to-sast-style.css
+- header now uses gradient from SAST
+- severity colours tokenised via CSS variables
+- severity icons added
+- DOM: wrapper .project__header retained; added .card__header to vuln card
+- images copied from SAST via data URI for external links
+- tested Chrome/Firefox/Edge and print mode
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Snyk SCA Test Report</title>
+  <base target="_blank">
+  <link rel="stylesheet" href="sca-to-sast-style.css">
+</head>
+<body class="section-projects">
+  <main class="layout-stacked">
+    <div class="layout-stacked__header header">
+      <header class="project__header">
+        <div class="layout-container">
+          <a class="brand" href="https://snyk.io" title="Snyk">
+            <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img">
+              <title>Snyk - Open Source Security</title>
+              <g fill="#fff"><path d="M5.732 27.278C3.445 27.278 1.589 26.885 0 26.124l.483-3.652C2.163 23.296 4.056 23.689 5.643 23.689c1.158 0 1.92-.394 1.92-1.09 0-2.005-7.23-1.523-7.23-6.76 0-3.348 3.074-5.11 6.926-5.11 1.92 0 3.902.52 5.185.975l-.52 3.59c-1.347-.52-3.177-1.003-4.702-1.003-.94 0-1.704.33-1.704.94 0 1.977 7.385 1.584 7.385 6.694 0 3.4-3.026 5.352-7.17 5.352zM25.726 26.936V17.894c0-2.067-.915-3.044-2.657-3.044-.85 0-1.74.24-2.35.61v11.476h-5.367V11.262l5.25-.432-.128 2.562h.178c1.132-1.522 3.05-2.676 5.34-2.676 2.744 0 5.12 1.7 5.12 5.72v10.5h-5.388zM61.175 26.936l-4.296-7.457h-.433v7.456H51.082V8.37l5.365-8.37v17.323c1.068-1.306 4.665-6.264 4.665-6.264h6.62l-6.278 6.63 6.495 9.261h-6.774zM44.13 11.11l-2.2 7.152c-.43 1.344-.85 3.817-.85 3.817s-.33-2.563-.788-3.907l-2.352-7.154H31.928l6.534 15.827c-.89 2.105-2.263 3.88-4.093 3.88-.33 0-.66-.013-.98-.05l-2.134 3.296c.673.38 1.957.774 3.482.774 3.966 0 6.622-3.208 8.478-7.95l6.228-15.777H44.13z"/></g>
+            </svg>
+          </a>
+          <div class="header-wrap">
+            <h1 class="project__header__title">Snyk test report</h1>
+            <p class="timestamp">TIMESTAMP</p>
+          </div>
+          <div class="source-panel">
+            <span>Scanned the following path:</span>
+            <ul>
+              <li class="paths">/path/to/project (npm)</li>
+            </ul>
+          </div>
+          <div class="meta-counts">
+            <div class="meta-count"><span>5</span> <span>known vulnerabilities</span></div>
+            <div class="meta-count"><span>8 vulnerable dependency paths</span></div>
+            <div class="meta-count"><span>135</span> <span>dependencies</span></div>
+          </div>
+        </div>
+      </header>
+    </div>
+    <section class="layout-container">
+      <table class="metatable">
+        <tbody>
+          <tr class="meta-row"><th class="meta-row-label">Project</th> <td class="meta-row-value">demo-project</td></tr>
+          <tr class="meta-row"><th class="meta-row-label">Path</th> <td class="meta-row-value">/path/to/project</td></tr>
+          <tr class="meta-row"><th class="meta-row-label">Package Manager</th> <td class="meta-row-value">npm</td></tr>
+          <tr class="meta-row"><th class="meta-row-label">Manifest</th> <td class="meta-row-value">package.json</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <div class="layout-container" style="padding-top:35px;">
+      <div class="cards--vuln filter--patch filter--ignore">
+        <div class="card card--vuln severity--high" data-snyk-test="high">
+          <input type="radio" name="tab-view-0" id="tab-dataflow-0" value="dataflow" class="card__tab__radio" checked>
+          <input type="radio" name="tab-view-0" id="tab-fix-0" value="fix" class="card__tab__radio">
+          <header class="card__header">
+            <div class="card__header__main">
+              <div class="severity-icon severity-icon--high"></div>
+              <h2 class="card__title">Regular Expression Denial of Service (ReDoS)</h2>
+              <div class="card__actions">
+                <label for="tab-dataflow-0" class="card__action">Data Flow</label>
+                <label for="tab-fix-0" class="card__action">Fix Analysis</label>
+              </div>
+            </div>
+            <ul class="card__meta">
+              <li class="card__meta__item">npm</li>
+              <li class="card__meta__item">CWE-400</li>
+              <li class="card__meta__item">brace-expansion</li>
+            </ul>
+          </header>
+          <div class="card__section">
+            <div class="label label--high"><span class="label__text">high severity</span></div>
+            <div class="card__summary severity--high">
+              <p>Package brace-expansion is vulnerable to ReDoS.</p>
+              <div class="file-location">Found in: <strong>index.js (line : 10)</strong></div>
+            </div>
+            <div class="card__panel dataflow" data-pane="dataflow">
+              <h2 class="card__panel__heading"><span class="heading-char">⇣</span> Data Flow</h2>
+              <div class="dataflow__item"><span class="dataflow__lineno">10:1</span><div class="dataflow__code"><span class="marker">user input</span></div></div>
+            </div>
+            <div class="card__panel fix-analysis" data-pane="fix">
+              <h2 class="card__panel__heading"><span class="heading-char">✓</span> Fix Analysis</h2>
+              <div class="card__panel__markdown"><p>Upgrade brace-expansion to version 1.1.7 or higher.</p></div>
+            </div>
+          </div>
+          <div class="cta card__cta"><p><a href="https://snyk.io/vuln/npm:brace-expansion:20170302">More about this vulnerability</a></p></div>
+        </div>
+      </div>
+    </div>
+  </main>
+<script>
+  const remediations = document.querySelectorAll('.js-remediation');
+  remediations.forEach(r => { r.parentElement.classList.toggle('shown'); r.addEventListener('click', remediationClick); });
+  const allPanes = document.querySelectorAll('[data-pane]');
+  allPanes.forEach(p => { p.classList.remove('shown'); });
+  const remediationNav = document.querySelectorAll('.js-nav');
+  remediationNav.forEach(nav => { nav.addEventListener('click', navClick); });
+  if (remediationNav && remediationNav.length > 0) {
+    remediationNav[0].classList.add('active');
+    const targetPaneData = remediationNav[0].dataset && remediationNav[0].dataset.toggle;
+    if (targetPaneData) { showPane(targetPaneData); }
+  }
+  function remediationClick(){ this.parentElement.classList.toggle('shown'); }
+  function navClick(){
+    const remediationNav=document.querySelectorAll('.js-nav');
+    remediationNav.forEach(nav=>{ nav.classList.remove('active'); });
+    this.classList.toggle('active');
+    const targetPaneData=this.dataset&&this.dataset.toggle;
+    if(targetPaneData){ showPane(targetPaneData); }
+  }
+  function showPane(targetPaneData){
+    const targetPanes=document.querySelectorAll(`[data-pane='${targetPaneData}']`);
+    if(targetPanes){
+      const allPanes=document.querySelectorAll('[data-pane]');
+      allPanes.forEach(p=>{ p.classList.remove('shown'); });
+      targetPanes[0].classList.add('shown');
+    }
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add modern SCA HTML template and partials
- wire new `--modern` CLI flag to use modern template
- register modern partials in template renderer
- document the new option in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd51fbf708321a1bdc03dfa9d058e